### PR TITLE
Update text in theme, tracks, and about us sections

### DIFF
--- a/views/about.pug
+++ b/views/about.pug
@@ -6,7 +6,7 @@ section#themes_and_tracks
         .col-xs-12.fadeInUp(data-animation='fadeInUp')
           .services-item
             h3 ProfHacks IV
-            p Rowan University’s student branch of the IEEE (Institute of Electrical and Electronics Engineers) is hosting its third hackathon! Located in Glassboro, New Jersey and just half an hour away from Philadelphia, Rowan University is proud to host this event and welcomes anyone, from first-timers to full-stack devs. If you have a cool technology idea that you want to make happen, this event is for you!
+            p Rowan University’s student branch of the IEEE (Institute of Electrical and Electronics Engineers) is hosting its fourth hackathon! Located in Glassboro, New Jersey and just half an hour away from Philadelphia, Rowan University is proud to host this event and welcomes anyone, from first-timers to full-stack devs. If you have a cool technology idea that you want to make happen, this event is for you!
 
         .col-xs-12.fadeInUp(data-animation='fadeInUp')
           .services-item

--- a/views/themes_and_tracks.pug
+++ b/views/themes_and_tracks.pug
@@ -19,13 +19,13 @@ section#themes_and_tracks.section-padding
             .icon
               i.far.fa-newspaper
             h3 Sensor Journalism
-            p Smart Cities of Tomorrow aims to connect technology with users on a larger scale. Think of all the problems in your town or nearest city. From connecting cars, to warehouses, to even traffic lights, Smart Cities of Tomorrow allows you to improve efficiency on a massive scale. Bring technology to its full potential and improve the world around you.
+            p Data is all around us, from the amount of air we breathe to the frequency of potholes on the roads we use to get to work. By collecting this data, we can use a network of sensors to create patterns in the environment that can be measured and predicted. How will you use data to tell a story?
         .col-lg-4.col-md-6.col-xs-12.fadeInUp(data-animation='fadeInUp', data-delay='300')
           .services-item
             .icon
               i.fas.fa-plug
             h3 IEEE Student Branch
-            p Data is all around us, from the amount of air we breathe to the frequency of potholes on the roads we use to get to work. By collecting this data, we can use a network of sensors to create patterns in the environment that can be measured and predicted. How will you use data to tell a story?
+            p Are you or one of your teammates an IEEE member? If so, then this may be the track for you! Design a product that helps advance technology for the benefit of humanity. Cities come in all shapes and sizes. Create a product that can accommodate for those differences and improve people’s quality of life. 
         .col-lg-4.col-md-6.col-xs-12.fadeInUp(data-animation='fadeInUp', data-delay='600')
           .services-item
             .icon


### PR DESCRIPTION
Updates the paragraphs of text under each heading to match the 2018 site, acts as a template for now. Corrects error in about us section.