### PR TITLE
Rearrange FAQ into grid

### DIFF
--- a/views/faq.pug
+++ b/views/faq.pug
@@ -3,36 +3,53 @@ section#FAQ
     .row.justify-content-center
       .col-md-8.col-lg-8.col-xs-12.text-center
         h2.section-title FAQ
-        .col-xs-12.fadeInUp(data-animation='fadeInUp')
-          .services-item
-            h3 Who can attend?
-            p Any high school, undergraduate, and graduate students are welcome to attend.
-        .col-xs-12.fadeInUp(data-animation='fadeInUp')
-          .services-item
-            h3 Do I need programming or hardware experience to compete?
-            p Of course not! We encourage all to participate. We will also have workshops
-            | and mentors to help everyone who attends.
-            h3 How will applicants be reviewed?
-            p Applications will be reviewed by the ProfHacks committee and selected participants
-            | will be notified via email. Rowan students are guaranteed acceptance to this 
-            | event, but will still need to apply.
-            h3 How much is this going to cost me?
-            p Profhacks is completely free! Food, drinks, and awesome swag are completely 
-            | free of charge!
-            h3 Where should I park?
-            p You can park in Parking Lot D, right next to the engineering building.
-            h3 What about team sizes?
-            p The maximum number of people a team can have is four. Though encouraged, having
-            | a team beforehand is not necessary. If you want to form a team at ProfHacks, 
-            | there will be a fun mixer beforehand to help you meet potential team members.
-            h3 What should I bring?
-            p You should bring some form of identification
-            | (driver's license, school ID card, etc.), 
-            | laptops, phones, chargers, and sleeping gear.
-            h3 What shouldn't I bring?
-            p Tools such as power drills, Dremel drills, soldering irons, and the like are
-            | prohibited. Articles such as weapons and alcohol are also prohibited.
-            | Any competitor found to be in possession of these articles
-            | will be disqualified from the competition.
-            h3 Do we have travel reimbursement?
-            p Unfortunately, we will not be offering travel reimbursement.
+    .row
+      .col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 Who can attend?
+          p Any high school, undergraduate, and graduate students are welcome to attend.
+      .col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 Do I need programming or hardware experience to compete?
+          p Of course not! We encourage all to participate. We will also have workshops
+          | and mentors to help everyone who attends.
+      .col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 How will applicants be reviewed?
+          p Applications will be reviewed by the ProfHacks committee and selected participants
+          | will be notified via email. Rowan students are guaranteed acceptance to this 
+          | event, but will still need to apply.
+    .row
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 How much is this going to cost me?
+          p Profhacks is completely free! Food, drinks, and awesome swag are completely 
+          | free of charge!
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 Where should I park?
+          p You can park in Parking Lot D, right next to the engineering building.
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 What about team sizes?
+          p The maximum number of people a team can have is four. Though encouraged, having
+          | a team beforehand is not necessary. If you want to form a team at ProfHacks, 
+          | there will be a fun mixer beforehand to help you meet potential team members.
+    .row
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 What should I bring?
+          p You should bring some form of identification
+          | (driver's license, school ID card, etc.), 
+          | laptops, phones, chargers, and sleeping gear.
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 What shouldn't I bring?
+          p Tools such as power drills, Dremel drills, soldering irons, and the like are
+          | prohibited. Articles such as weapons and alcohol are also prohibited.
+          | Any competitor found to be in possession of these articles
+          | will be disqualified from the competition.
+      .col.col-md-4.col-lg-4.col-xs-12.fadeInUp(data-animation='fadeInUp').text-center
+        .services-item
+          h3 Do we have travel reimbursement?
+          p Unfortunately, we will not be offering travel reimbursement.


### PR DESCRIPTION
Sets up the basic gridwork for the FAQ to be grid-shaped like the themes and tracks section. There is some odd whitespace that might want to be fixed. 